### PR TITLE
Default-SlugOptions bei Alias-Ermittlung berücksichtigen

### DIFF
--- a/src/DataContainer/CompanyContainer.php
+++ b/src/DataContainer/CompanyContainer.php
@@ -50,9 +50,15 @@ class CompanyContainer
             return $result->numRows > 0;
         };
 
+        // Get min. PageId to get default SlugOptions
+        $minPageId = Database::getInstance()
+            ->prepare('SELECT min(id) n FROM tl_page WHERE published=1')
+            ->limit(1)
+            ->execute();
+
         // Generate alias if there is none
         if (!$value) {
-            $value = $this->slug->generate($dc->activeRecord->title, 0, $aliasExists);
+            $value = $this->slug->generate($dc->activeRecord->title, $minPageId->n ?? 1, $aliasExists);
         } elseif (preg_match('/^[1-9]\d*$/', (string) $value)) {
             throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['aliasNumeric'], $value));
         } elseif ($aliasExists($value)) {


### PR DESCRIPTION
Im Contao-Core wird zB bei dein Events die jumpTo-Page des Event-Archives verwendet um die SlugOptions dieser Seite zu verwenden. Da das Company-Archiv keinen jumpTo-Parameter hat, wäre diese ein Vorschlag für einen Workaround.